### PR TITLE
Video ids recent media

### DIFF
--- a/fixtures/tag_recent_media.json
+++ b/fixtures/tag_recent_media.json
@@ -189,6 +189,135 @@
                 "id": "5273",
                 "last_name": ""
             }
+        },
+        {
+            "id": "1614083460929239315_25025320",
+            "user": {
+                "id": "25025320",
+                "full_name": "Instagram",
+                "profile_picture": "https://scontent.cdninstagram.com/t51.2885-19/s150x150/14719833_310540259320655_1605122788543168512_a.jpg",
+                "username": "instagram"
+            },
+            "images": {
+                "thumbnail": {
+                    "width": 150,
+                    "height": 150,
+                    "url": "https://scontent.cdninstagram.com/t51.2885-15/s150x150/e15/21980918_1513931928693772_9033863567060762624_n.jpg"
+                },
+                "low_resolution": {
+                    "width": 320,
+                    "height": 320,
+                    "url": "https://scontent.cdninstagram.com/t51.2885-15/s320x320/e15/21980918_1513931928693772_9033863567060762624_n.jpg"
+                },
+                "standard_resolution": {
+                    "width": 640,
+                    "height": 640,
+                    "url": "https://scontent.cdninstagram.com/t51.2885-15/s640x640/e15/21980918_1513931928693772_9033863567060762624_n.jpg"
+                }
+            },
+            "created_time": "1506633764",
+            "caption": {
+                "id": "17900429008029332",
+                "text": "Hello, world! It\u2019s time for another dose of #WeeklyFluff. Meet Kuzuki (@sou_ham), a happy hamster from Japan who has been described as a \u201csmall vacuum cleaner.\u201d Follow @sou_ham to make sure you never miss one of Kuzuki\u2019s \u2014 or Uzuki's! (the other hamster in the family) \u2014 adventures. \ud83d\udc39\ud83d\udc39",
+                "created_time": "1506633764",
+                "from": {
+                    "id": "25025320",
+                    "full_name": "Instagram",
+                    "profile_picture": "https://scontent.cdninstagram.com/t51.2885-19/s150x150/14719833_310540259320655_1605122788543168512_a.jpg",
+                    "username": "instagram"
+                }
+            },
+            "user_has_liked": false,
+            "likes": {
+                "count": 821506
+            },
+            "tags": ["weeklyfluff"],
+            "filter": "Normal",
+            "comments": {
+                "count": 15562
+            },
+            "type": "video",
+            "link": "http://localhost:8000/p/BZmYFsehTkT/",
+            "location": null,
+            "attribution": null,
+            "users_in_photo": [],
+            "videos": {
+                "standard_resolution": {
+                    "width": 640,
+                    "height": 640,
+                    "url": "https://scontent.cdninstagram.com/t50.2886-16/22137988_1621796317884357_179940820256817152_n.mp4",
+                    "id": "0"
+                },
+                "low_bandwidth": {
+                    "width": 480,
+                    "height": 480,
+                    "url": "https://scontent.cdninstagram.com/t50.2886-16/22112778_357761027970441_6775862658118713344_n.mp4",
+                    "id": "0"
+                },
+                "low_resolution": {
+                    "width": 480,
+                    "height": 480,
+                    "url": "https://scontent.cdninstagram.com/t50.2886-16/22112778_357761027970441_6775862658118713344_n.mp4",
+                    "id": "0"
+                }
+            }
+        },
+        {
+            "id": "1613267810091631142_25025320",
+            "user": {
+                "id": "25025320",
+                "full_name": "Instagram",
+                "profile_picture": "https://scontent.cdninstagram.com/t51.2885-19/s150x150/14719833_310540259320655_1605122788543168512_a.jpg",
+                "username": "instagram"
+            },
+            "images": {
+                "thumbnail": {
+                    "width": 150,
+                    "height": 150,
+                    "url": "https://scontent.cdninstagram.com/t51.2885-15/s150x150/e35/21985313_400032113744601_677307280198205440_n.jpg"
+                },
+                "low_resolution": {
+                    "width": 320,
+                    "height": 320,
+                    "url": "https://scontent.cdninstagram.com/t51.2885-15/s320x320/e35/21985313_400032113744601_677307280198205440_n.jpg"
+                },
+                "standard_resolution": {
+                    "width": 640,
+                    "height": 640,
+                    "url": "https://scontent.cdninstagram.com/t51.2885-15/s640x640/sh0.08/e35/21985313_400032113744601_677307280198205440_n.jpg"
+                }
+            },
+            "created_time": "1506536531",
+            "caption": {
+                "id": "17874787510182141",
+                "text": "Photo by @naomijon\nBlue hair. Blue eyes. \u201cThese two things are kind of my trademark,\u201d says German beauty blogger Naomi Jon (@naomijon). \u201cIf I had to choose between black and any color, I would always go for the color, because it\u2019s way more exciting, and it always attracts attention.\u201d\nWatch Naomi apply a colorful eye shadow combination on our Instagram story right now. \ud83d\udc99",
+                "created_time": "1506536531",
+                "from": {
+                    "id": "25025320",
+                    "full_name": "Instagram",
+                    "profile_picture": "https://scontent.cdninstagram.com/t51.2885-19/s150x150/14719833_310540259320655_1605122788543168512_a.jpg",
+                    "username": "instagram"
+                }
+            },
+            "user_has_liked": false,
+            "likes": {
+                "count": 590414
+            },
+            "tags": [],
+            "filter": "Normal",
+            "comments": {
+                "count": 6413
+            },
+            "type": "image",
+            "link": "https://www.instagram.com/p/BZjeoacFYIm/",
+            "location": {
+                "latitude": 52.3667,
+                "longitude": 9.71667,
+                "name": "Hanover, Germany",
+                "id": 213305671
+            },
+            "attribution": null,
+            "users_in_photo": []
         }
     ]
 }

--- a/instagram/models.py
+++ b/instagram/models.py
@@ -23,10 +23,13 @@ class ApiModel(object):
 
 
 class Image(ApiModel):
-    def __init__(self, url, width, height):
+    def __init__(self, url, width, height, id=None):
         self.url = url
         self.height = height
         self.width = width
+
+        if id:  # don't store ids None and 0, just provide support for what seems to be an upcoming API change
+            self.id = id
 
     def __unicode__(self):
         return "Image: %s" % self.url


### PR DESCRIPTION
Apparently the serialized media objects can contain a bogus `"id": "0"`, which breaks de-serialization.
This adds support for the id field - only storing it if it is sane - and relevant test case.